### PR TITLE
Add Command + Enter shortcut for message sending

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -59,7 +59,7 @@ type GlobalStateKey =
 	| "openRouterModelId"
 	| "openRouterModelInfo"
 	| "soundEnabled"
-
+	| "commandEnterToSend"
 export const GlobalFileNames = {
 	apiConversationHistory: "api_conversation_history.json",
 	uiMessages: "ui_messages.json",
@@ -493,12 +493,19 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 							playSound(soundPath)
 						}
 						break
-					case "soundEnabled":
+					case "soundEnabled":{
 						const enabled = message.bool ?? true
 						await this.updateGlobalState("soundEnabled", enabled)
 						setSoundEnabled(enabled) // sound.tsから import
 						await this.postStateToWebview()
 						break
+					}
+					case "commandEnterToSend":{
+						const enabled = message.bool ?? false
+						await this.updateGlobalState("commandEnterToSend", enabled)
+						await this.postStateToWebview()
+						break
+					}
 				}
 			},
 			null,
@@ -803,6 +810,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			alwaysAllowReadOnly,
 			taskHistory,
 			soundEnabled,
+			commandEnterToSend,
 		} = await this.getState()
 		return {
 			version: this.context.extension?.packageJSON?.version ?? "",
@@ -812,6 +820,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			uriScheme: vscode.env.uriScheme,
 			clineMessages: this.cline?.clineMessages || [],
 			soundEnabled: soundEnabled ?? true,
+			commandEnterToSend: commandEnterToSend ?? false,
 			taskHistory: (taskHistory || []).filter((item) => item.ts && item.task).sort((a, b) => b.ts - a.ts),
 			shouldShowAnnouncement: lastShownAnnouncementId !== this.latestAnnouncementId,
 		}
@@ -899,6 +908,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			alwaysAllowReadOnly,
 			taskHistory,
 			soundEnabled,
+			commandEnterToSend,
 		] = await Promise.all([
 			this.getGlobalState("apiProvider") as Promise<ApiProvider | undefined>,
 			this.getGlobalState("apiModelId") as Promise<string | undefined>,
@@ -929,6 +939,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			this.getGlobalState("alwaysAllowReadOnly") as Promise<boolean | undefined>,
 			this.getGlobalState("taskHistory") as Promise<HistoryItem[] | undefined>,
 			this.getGlobalState("soundEnabled") as Promise<boolean | undefined>,
+			this.getGlobalState("commandEnterToSend") as Promise<boolean | undefined>,
 		])
 
 		let apiProvider: ApiProvider
@@ -977,6 +988,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			alwaysAllowReadOnly: alwaysAllowReadOnly ?? false,
 			taskHistory,
 			soundEnabled,
+			commandEnterToSend,
 		}
 	}
 

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -38,6 +38,7 @@ export interface ExtensionState {
 	taskHistory: HistoryItem[]
 	shouldShowAnnouncement: boolean
 	soundEnabled?: boolean
+	commandEnterToSend?: boolean
 }
 
 export interface ClineMessage {

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -27,6 +27,7 @@ export interface WebviewMessage {
 		| "refreshOpenRouterModels"
 		| "playSound"
 		| "soundEnabled"
+		| "commandEnterToSend"
 	text?: string
 	askResponse?: ClineAskResponse
 	apiConfiguration?: ApiConfiguration

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -42,7 +42,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		},
 		ref,
 	) => {
-		const { filePaths } = useExtensionState()
+		const { filePaths, commandEnterToSend } = useExtensionState()
 		const [isTextAreaFocused, setIsTextAreaFocused] = useState(false)
 		const [thumbnailsHeight, setThumbnailsHeight] = useState(0)
 		const [textAreaBaseHeight, setTextAreaBaseHeight] = useState<number | undefined>(undefined)
@@ -200,6 +200,11 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 
 				const isComposing = event.nativeEvent?.isComposing ?? false
 				if (event.key === "Enter" && !event.shiftKey && !isComposing) {
+					if ((commandEnterToSend ?? false) && !event.metaKey) {
+						console.log('hello')
+						return
+					}
+					console.log('goodbye')
 					event.preventDefault()
 					onSend()
 				}
@@ -240,19 +245,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					}
 				}
 			},
-			[
-				onSend,
-				showContextMenu,
-				searchQuery,
-				selectedMenuIndex,
-				handleMentionSelect,
-				selectedType,
-				inputValue,
-				cursorPosition,
-				setInputValue,
-				justDeletedSpaceAfterMention,
-				queryItems,
-			],
+			[showContextMenu, selectedMenuIndex, searchQuery, selectedType, queryItems, handleMentionSelect, commandEnterToSend, onSend, inputValue, cursorPosition, justDeletedSpaceAfterMention, setInputValue],
 		)
 
 		useLayoutEffect(() => {

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -22,6 +22,8 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 		soundEnabled,
 		setSoundEnabled,
 		openRouterModels,
+		commandEnterToSend,
+		setCommandEnterToSend,
 	} = useExtensionState()
 	const [apiErrorMessage, setApiErrorMessage] = useState<string | undefined>(undefined)
 	const [modelIdErrorMessage, setModelIdErrorMessage] = useState<string | undefined>(undefined)
@@ -36,6 +38,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 			vscode.postMessage({ type: "customInstructions", text: customInstructions })
 			vscode.postMessage({ type: "alwaysAllowReadOnly", bool: alwaysAllowReadOnly })
 			vscode.postMessage({ type: "soundEnabled", bool: soundEnabled })
+			vscode.postMessage({ type: "commandEnterToSend", bool: commandEnterToSend })
 			onDone()
 		}
 	}
@@ -143,6 +146,22 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 							color: "var(--vscode-descriptionForeground)",
 						}}>
 						When enabled, Cline will play sound effects for notifications and events.
+					</p>
+				</div>
+				<div style={{ marginBottom: 5 }}>
+					<VSCodeCheckbox
+						checked={commandEnterToSend}
+						onChange={(e: any) => setCommandEnterToSend(e.target.checked)}>
+						<span style={{ fontWeight: "500" }}>Use Command + Enter to send messages</span>
+					</VSCodeCheckbox>
+					<p
+						style={{
+							fontSize: "12px",
+							marginTop: "5px",
+							color: "var(--vscode-descriptionForeground)",
+						}}>
+						When enabled, messages will be sent using Command + Enter. When disabled, messages will be sent
+						using Enter.
 					</p>
 				</div>
 				{IS_DEV && (

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -22,6 +22,7 @@ interface ExtensionStateContextType extends ExtensionState {
 	setAlwaysAllowReadOnly: (value: boolean) => void
 	setShowAnnouncement: (value: boolean) => void
 	setSoundEnabled: (value: boolean) => void
+	setCommandEnterToSend: (value: boolean) => void
 }
 
 const ExtensionStateContext = createContext<ExtensionStateContextType | undefined>(undefined)
@@ -33,6 +34,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		taskHistory: [],
 		shouldShowAnnouncement: false,
 		soundEnabled: true,
+		commandEnterToSend: false,
 	})
 	const [didHydrateState, setDidHydrateState] = useState(false)
 	const [showWelcome, setShowWelcome] = useState(false)
@@ -118,6 +120,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		setAlwaysAllowReadOnly: (value) => setState((prevState) => ({ ...prevState, alwaysAllowReadOnly: value })),
 		setShowAnnouncement: (value) => setState((prevState) => ({ ...prevState, shouldShowAnnouncement: value })),
 		setSoundEnabled: (value) => setState((prevState) => ({ ...prevState, soundEnabled: value })),
+		setCommandEnterToSend: (value) => setState((prevState) => ({ ...prevState, commandEnterToSend: value })),
 	}
 
 	return <ExtensionStateContext.Provider value={contextValue}>{children}</ExtensionStateContext.Provider>


### PR DESCRIPTION
This PR implements a new feature that allows users to send messages using Command + Enter shortcut.

Changes:
- Add new option for message sending shortcut
- Implement Command + Enter handling in ChatTextArea
- Update related configurations and handlers

This enhancement improves user experience by providing a familiar shortcut for message submission.